### PR TITLE
add pi5 support for upload.sh 

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -12,13 +12,19 @@ fi
 OPERATION=$1
 UF2_FILE=$2
 
-# GPIO Numbers, 
-# on Jetson, pin 7 is gpio216 and pin 11 is gpio50
-# on RPi pin 7 is gpio4, pin 11 is gpio17
-if grep -q "Raspberry Pi" /proc/device-tree/model; then
-  echo "Detected Raspberry Pi, entering $1 mode..."
+# GPIO Pin Mapping:
+# RUN (Pin 7) and LOAD (Pin 11)
+# Jetson: Pin 7 -> GPIO 216, Pin 11 -> GPIO 50
+#   Pi 4: Pin 7 -> GPIO 4, Pin 11 -> GPIO 17
+#   Pi 5: Pin 7 -> GPIO 575, Pin 11 -> GPIO 588
+if grep -q "Raspberry Pi 4" /proc/device-tree/model; then
+  echo "Detected Raspberry Pi 4, entering $1 mode..."
   BTLD_PIN=4
   RUN_PIN=17
+elif grep -q "Raspberry Pi 5" /proc/device-tree/model; then
+  echo "Detected Raspberry Pi 5, entering $1 mode..."
+  BTLD_PIN=588
+  RUN_PIN=575
 elif grep -q "NVIDIA Jetson" /proc/device-tree/model; then
   echo "Detected NVIDIA Jetson, entering $1 mode..."
   BTLD_PIN=50


### PR DESCRIPTION
### Issue
upload.sh doesn't support Pi 5
```
$ sudo ./upload.sh flash build/src/mbot_classic.uf2
Detected Raspberry Pi 5, entering flash mode...
./upload.sh: line 41: echo: write error: Invalid argument
./upload.sh: line 43: /sys/class/gpio/gpio4/direction: No such file or directory
./upload.sh: line 50: echo: write error: Invalid argument
./upload.sh: line 52: /sys/class/gpio/gpio17/direction: No such file or directory
Flashing action for build/src/mbot_classic.uf2...
./upload.sh: line 91: /sys/class/gpio/gpio17/value: No such file or directory
./upload.sh: line 93: /sys/class/gpio/gpio4/value: No such file or directory
./upload.sh: line 95: /sys/class/gpio/gpio17/value: No such file or directory
No accessible RP2040 devices in BOOTSEL mode were found.
./upload.sh: line 99: /sys/class/gpio/gpio4/value: No such file or directory
No accessible RP2040 devices in BOOTSEL mode were found.
```

### What's new
Added PI 5 detection to upload.sh, and gives it kernel GPIO numbers to toggle, instead of the GPIO/BCM number. Now upload.sh works fine.

### Why
This transition is due to changes in how the Linux kernel handles GPIO, moving from the older sysfs interface (sysfs is mapped to `/sys/class/gpio/gpioXXX`) to the newer character device interface (via `/dev/gpiochipN`). Seems using `gpiod` is the future. For now to solve the problem with the minimum change, we are just going to use the kernel number.

Jetson, Pi4, and Pi5 all use 40-pin GPIO header. 
|      | RUN| LOAD |
| ---  |--- | ---|
|Physical pin|PIN 7|PIN 11|
|Pi4 GPIO/BCM number| GPIO4 | GPIO17 |
|Pi5 GPIO/BCM number| GPIO4 | GPIO17 |
|Pi4 Kernel GPIO Number|\ | \ |
|Pi5 Kernel GPIO Number|gpio-575| gpio-588 |

```
$ sudo cat /sys/kernel/debug/gpio | grep '(GPIO'
 gpio-573 (GPIO2               )
 gpio-574 (GPIO3               )
 gpio-575 (GPIO4               |sysfs               ) out hi 
 gpio-576 (GPIO5               )
 gpio-577 (GPIO6               )
 gpio-578 (GPIO7               )
 gpio-579 (GPIO8               )
 gpio-580 (GPIO9               )
 gpio-581 (GPIO10              )
 gpio-582 (GPIO11              )
 gpio-583 (GPIO12              )
 gpio-584 (GPIO13              )
 gpio-585 (GPIO14              )
 gpio-586 (GPIO15              )
 gpio-587 (GPIO16              )
 gpio-588 (GPIO17              |sysfs               ) out hi 
 gpio-589 (GPIO18              )
 gpio-590 (GPIO19              )
 gpio-591 (GPIO20              )
 gpio-592 (GPIO21              )
 gpio-593 (GPIO22              )
 gpio-594 (GPIO23              )
 gpio-595 (GPIO24              )
 gpio-596 (GPIO25              )
 gpio-597 (GPIO26              )
 gpio-598 (GPIO27              )
```