### PR TITLE
Bugfix/drive slow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,9 @@ set(CMAKE_PROJECT_VERSION 1.0.0)
 add_definitions(-DVERSION="${CMAKE_PROJECT_VERSION}")
 
 # Add an option to toggle between CLASSIC and OMNI with CLASSIC as default
-set(MBOT_TYPE "CLASSIC" CACHE STRING "MBot type to build: CLASSIC or OMNI")
-set(ENC "" CACHE STRING "Encoder resolution: 20, 40, or 48")
-set(OMNI_WHEEL_DIAMETER "" CACHE STRING "Wheel diameter for the Omni in mm: 101 or 96")
+set(MBOT_TYPE "OMNI" CACHE STRING "MBot type to build: CLASSIC or OMNI")
+set(ENC "48" CACHE STRING "Encoder resolution: 20, 40, or 48")
+set(OMNI_WHEEL_DIAMETER "96" CACHE STRING "Wheel diameter for the Omni in mm: 101 or 96")
 
 # Check that the user-defined option is either CLASSIC or OMNI
 if(NOT MBOT_TYPE STREQUAL "CLASSIC" AND NOT MBOT_TYPE STREQUAL "OMNI")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
-set(CMAKE_PROJECT_VERSION 1.0.0)
+set(CMAKE_PROJECT_VERSION 1.0.0 CACHE STRING "Project version")
 
 # Expose the version to the source code.
 add_definitions(-DVERSION="${CMAKE_PROJECT_VERSION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,9 @@ set(CMAKE_PROJECT_VERSION 1.0.0)
 add_definitions(-DVERSION="${CMAKE_PROJECT_VERSION}")
 
 # Add an option to toggle between CLASSIC and OMNI with CLASSIC as default
-set(MBOT_TYPE "OMNI" CACHE STRING "MBot type to build: CLASSIC or OMNI")
-set(ENC "48" CACHE STRING "Encoder resolution: 20, 40, or 48")
-set(OMNI_WHEEL_DIAMETER "96" CACHE STRING "Wheel diameter for the Omni in mm: 101 or 96")
+set(MBOT_TYPE "CLASSIC" CACHE STRING "MBot type to build: CLASSIC or OMNI")
+set(ENC "" CACHE STRING "Encoder resolution: 20, 40, or 48")
+set(OMNI_WHEEL_DIAMETER "" CACHE STRING "Wheel diameter for the Omni in mm: 101 or 96")
 
 # Check that the user-defined option is either CLASSIC or OMNI
 if(NOT MBOT_TYPE STREQUAL "CLASSIC" AND NOT MBOT_TYPE STREQUAL "OMNI")

--- a/build_all.sh
+++ b/build_all.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e  # Quit on error.
 
+# Supported configurations.
+CLASSIC_ENCODER_RES="20 40 48"
+OMNI_ENCODER_RES="20 48"
+OMNI_WHEEL_DIAMETER="96 101"
+
 if [ ! -d "build" ]; then
     mkdir build
 fi
@@ -8,32 +13,83 @@ fi
 rm -rf build/*  # Clear contents from old builds.
 cd build
 
-# CLASSIC with each encoder resolution (20, 40, 48).
+# CLASSIC with each encoder resolution.
 echo "*******************************"
 echo "*  BUILDING CLASSIC VERSIONS  *"
 echo "*******************************"
 echo
-cmake -DMBOT_TYPE=CLASSIC -DENC=20 .. && make
-cmake -DMBOT_TYPE=CLASSIC -DENC=40 .. && make
-cmake -DMBOT_TYPE=CLASSIC -DENC=48 .. && make
 
-# OMNI, 101mm wheels (old) with each encoder resolution (20, 48).
-echo
-echo "*******************************************"
-echo "*  BUILDING OMNI VERSIONS (101mm wheels)  *"
-echo "*******************************************"
-echo
-cmake -DMBOT_TYPE=OMNI -DOMNI_WHEEL_DIAMETER=101 -DENC=20 .. && make
-cmake -DMBOT_TYPE=OMNI -DOMNI_WHEEL_DIAMETER=101 -DENC=48 .. && make
+for enc in $CLASSIC_ENCODER_RES
+do
+    cmake -DMBOT_TYPE=CLASSIC -DENC=$enc .. && make
+done
 
-# OMNI, 96mm wheels (new) with each encoder resolution (20, 48).
+# OMNI, all combinations of wheel diameters and encoder resolutions..
 echo
-echo "*******************************************"
-echo "*  BUILDING OMNI VERSIONS (96mm wheels)   *"
-echo "*******************************************"
+echo "****************************"
+echo "*  BUILDING OMNI VERSIONS  *"
+echo "****************************"
 echo
-cmake -DMBOT_TYPE=OMNI -DOMNI_WHEEL_DIAMETER=96 -DENC=20 .. && make
-cmake -DMBOT_TYPE=OMNI -DOMNI_WHEEL_DIAMETER=96 -DENC=48 .. && make
+
+for wheel_dia in $OMNI_WHEEL_DIAMETER
+do
+    for enc in $OMNI_ENCODER_RES
+    do
+        cmake -DMBOT_TYPE=OMNI -DOMNI_WHEEL_DIAMETER=$wheel_dia -DENC=$enc .. && make
+    done
+done
 
 echo
-echo "Building all versions complete!"
+echo "Building all versions complete! Copying release files..."
+echo
+
+# Copy all the files for the release to a separate folder.
+
+# Extract the CMAKE_PROJECT_VERSION from the CMakeCache.txt file
+CMAKE_PROJECT_VERSION=$(grep -m 1 "CMAKE_PROJECT_VERSION:" "CMakeCache.txt" | sed 's/.*=//')
+
+# Check if the version was found
+if [ -z "$CMAKE_PROJECT_VERSION" ]; then
+  echo "CMAKE_PROJECT_VERSION not found in $CMAKECACHE_PATH."
+  exit 1
+fi
+
+# The files for this release will go here.
+RELEASE_DIR=release-v$CMAKE_PROJECT_VERSION/
+# If there was an old release directory, delete it.
+if [ -d $RELEASE_DIR ]; then
+    rm -rf $RELEASE_DIR
+fi
+mkdir $RELEASE_DIR
+
+# Classic files.
+for enc in $CLASSIC_ENCODER_RES
+do
+    cp mbot_classic_v${CMAKE_PROJECT_VERSION}_enc${enc}.uf2 $RELEASE_DIR
+    cp mbot_calibrate_classic_v${CMAKE_PROJECT_VERSION}_enc${enc}.uf2 $RELEASE_DIR
+done
+
+# Omni files.
+for wheel_dia in $OMNI_WHEEL_DIAMETER
+do
+    for enc in $OMNI_ENCODER_RES
+    do
+        cp mbot_omni_v${CMAKE_PROJECT_VERSION}_enc${enc}_w${wheel_dia}mm.uf2 $RELEASE_DIR
+        cp mbot_calibrate_omni_v${CMAKE_PROJECT_VERSION}_enc${enc}_w${wheel_dia}mm.uf2 $RELEASE_DIR
+    done
+done
+
+# Copy the tests.
+cp mbot_classic_motor_test.uf2 $RELEASE_DIR
+cp mbot_omni_motor_test.uf2 $RELEASE_DIR
+cp mbot_encoder_test.uf2 $RELEASE_DIR
+
+# Copy the upload script.
+cp ../mbot-upload-firmware $RELEASE_DIR
+
+echo "Done preparing release! The files for the release are in directory:"
+echo
+echo "build/$RELEASE_DIR"
+for item in "$RELEASE_DIR"/*; do
+  echo -e "\t$(basename "$item")"
+done

--- a/include/config/mbot_classic_config.h
+++ b/include/config/mbot_classic_config.h
@@ -6,7 +6,7 @@
 
 /* The user can set the encoder resolution to 20, 40, or 48 with a CMake arg. */
 #ifdef USER_ENCODER_RES
-#define ENCODER_RES             USER_ENCODER_RES
+#define ENCODER_RES             (float)USER_ENCODER_RES
 #else
 #define ENCODER_RES             48.0  // Default encoder resolution.
 #endif   /* USER_ENCODER_RES */

--- a/include/config/mbot_omni_config.h
+++ b/include/config/mbot_omni_config.h
@@ -4,23 +4,23 @@
 // #if OMNI_VERSION == 10
 /****************** OMNI Version 1.0*******************/
 // Hardware Parameters
-#define GEAR_RATIO              78.0
+#define GEAR_RATIO              78.0f
 
 /* The user can set the encoder resolution to 20 or 48 with a CMake arg. */
 #ifdef USER_ENCODER_RES
 #define ENCODER_RES             (float)USER_ENCODER_RES
 #else
-#define ENCODER_RES             48.0  // Default encoder resolution.
+#define ENCODER_RES             48.0f  // Default encoder resolution.
 #endif   /* USER_ENCODER_RES */
 
 // MBot Omni Parameters
-#define OMNI_BASE_RADIUS        0.10843     // Radius of base, from center of base to middle of omni wheels
+#define OMNI_BASE_RADIUS        0.10843f     // Radius of base, from center of base to middle of omni wheels
                                             // Base radius to outer surface on wheel is 0.1227
 /* The user can set the wheel diameter to 101 or 96 mm with a CMake arg. */
 #ifdef USER_OMNI_WHEEL_DIAMETER
-#define OMNI_WHEEL_RADIUS       (float)USER_OMNI_WHEEL_DIAMETER / 2000.0  // Convert to radius in meters.
+#define OMNI_WHEEL_RADIUS       ((float)USER_OMNI_WHEEL_DIAMETER / 2000.0f)  // Convert to radius in meters.
 #else
-#define OMNI_WHEEL_RADIUS       0.048       // Default wheel radius.
+#define OMNI_WHEEL_RADIUS       0.048f       // Default wheel radius.
 #endif   /* USER_ENCODER_RES */
 
 #define MOT_R               0   // Right motor slot

--- a/mbot-upload-firmware
+++ b/mbot-upload-firmware
@@ -34,23 +34,8 @@ else
   exit 1
 fi
 
-# Check if BTLD_PIN is exported and set direction if necessary
-if [ ! -e /sys/class/gpio/gpio$BTLD_PIN ]; then
-    echo $BTLD_PIN > /sys/class/gpio/export
-    sleep 0.1
-    echo out > /sys/class/gpio/gpio$BTLD_PIN/direction
-elif [ "$(cat /sys/class/gpio/gpio$BTLD_PIN/direction)" != "out" ]; then
-    echo out > /sys/class/gpio/gpio$BTLD_PIN/direction
-fi
-
-# Check if RUN_PIN is exported and set direction if necessary
-if [ ! -e /sys/class/gpio/gpio$RUN_PIN ]; then
-    echo $RUN_PIN > /sys/class/gpio/export
-    sleep 0.1
-    echo out > /sys/class/gpio/gpio$RUN_PIN/direction
-elif [ "$(cat /sys/class/gpio/gpio$RUN_PIN/direction)" != "out" ]; then
-    echo out > /sys/class/gpio/gpio$RUN_PIN/direction
-fi
+pinctrl set $BTLD_PIN op
+pinctrl set $RUN_PIN op
 
 sleep 0.1
 
@@ -62,11 +47,11 @@ case "$OPERATION" in
             "load")
                 echo "Loading action for $UF2_FILE..."
                 if [ -n "$UF2_FILE" ]; then
-                    echo 0 > /sys/class/gpio/gpio$RUN_PIN/value
+                    pinctrl set $RUN_PIN dl
                     sleep 0.1
-                    echo 0 > /sys/class/gpio/gpio$BTLD_PIN/value
+                    pinctrl set $BTLD_PIN dl
                     sleep 0.5
-                    echo 1 > /sys/class/gpio/gpio$RUN_PIN/value
+                    pinctrl set $RUN_PIN dh
                     sleep 0.5
                     sudo picotool load $UF2_FILE
                     sleep 0.5
@@ -76,25 +61,25 @@ case "$OPERATION" in
                 ;;
             "run")
                 echo "Running action for loaded UF2_FILE..."
-                echo 0 > /sys/class/gpio/gpio$RUN_PIN/value
+                pinctrl set $RUN_PIN dl
                 sleep 0.1
-                echo 1 > /sys/class/gpio/gpio$BTLD_PIN/value
+                pinctrl set $BTLD_PIN dh
                 sleep 0.5
-                echo 1 > /sys/class/gpio/gpio$RUN_PIN/value
+                pinctrl set $RUN_PIN dh
                 sleep 1
                 ;;
             "flash")
                 echo "Flashing action for $UF2_FILE..."
                 if [ -n "$UF2_FILE" ]; then
-                    echo 0 > /sys/class/gpio/gpio$RUN_PIN/value
+                    pinctrl set $RUN_PIN dl
                     sleep 0.1
-                    echo 0 > /sys/class/gpio/gpio$BTLD_PIN/value
+                    pinctrl set $BTLD_PIN dl
                     sleep 0.5
-                    echo 1 > /sys/class/gpio/gpio$RUN_PIN/value
+                    pinctrl set $RUN_PIN dh
                     sleep 0.5
                     sudo picotool load $UF2_FILE
                     sleep 0.5
-                    echo 1 > /sys/class/gpio/gpio$BTLD_PIN/value
+                    pinctrl set $BTLD_PIN dh
                     sleep 0.5
                     sudo picotool reboot
                 else
@@ -102,10 +87,10 @@ case "$OPERATION" in
                 fi
                 ;;
             "disable")
-                echo "Disable action..."    
-                echo 1 > /sys/class/gpio/gpio$BTLD_PIN/value
+                echo "Disable action..."
+                pinctrl set $BTLD_PIN dh
                 sleep 0.5
-                echo 0 > /sys/class/gpio/gpio$RUN_PIN/value
+                pinctrl set $RUN_PIN dl
                 sleep 1
                 ;;
         esac

--- a/src/mbot_omni.c
+++ b/src/mbot_omni.c
@@ -61,12 +61,19 @@ bool mbot_loop(repeating_timer_t *rt)
             mbot_motor_pwm_cmd.pwm[MOT_B] = _calibrated_pwm_from_vel_cmd(mbot_motor_vel_cmd.velocity[MOT_B], MOT_B);
         }else if(drive_mode == MODE_MBOT_VEL){
             //TODO: open loop for now - implement closed loop controller
-            mbot_motor_vel_cmd.velocity[MOT_L] = (SQRT3 / 2.0 * mbot_vel_cmd.vx - 0.5 * mbot_vel_cmd.vy - OMNI_BASE_RADIUS * mbot_vel_cmd.wz) / OMNI_WHEEL_RADIUS;
-            mbot_motor_vel_cmd.velocity[MOT_R] = (-SQRT3 / 2.0 * mbot_vel_cmd.vx - 0.5 * mbot_vel_cmd.vy - OMNI_BASE_RADIUS * mbot_vel_cmd.wz) / OMNI_WHEEL_RADIUS;
+
+            printf("vx: %f, vy: %f, wz: %f\n", mbot_vel_cmd.vx, mbot_vel_cmd.vy, mbot_vel_cmd.wz);
+            printf("sqrt3: %f, base_radius: %f, wheel_radius: %f\n", SQRT3, OMNI_BASE_RADIUS, OMNI_WHEEL_RADIUS);
+            printf("%f\n", ( ((SQRT3 / 2.0f) * mbot_vel_cmd.vx) - (mbot_vel_cmd.vy / 2.0f) - (OMNI_BASE_RADIUS * mbot_vel_cmd.wz) ) / OMNI_WHEEL_RADIUS);
+            printf("%f\n", (-SQRT3 / 2.0f * mbot_vel_cmd.vx - 0.5f * mbot_vel_cmd.vy - OMNI_BASE_RADIUS * mbot_vel_cmd.wz) / OMNI_WHEEL_RADIUS);
+            printf("%f\n", (mbot_vel_cmd.vy - OMNI_BASE_RADIUS * mbot_vel_cmd.wz) / OMNI_WHEEL_RADIUS);
+
+            mbot_motor_vel_cmd.velocity[MOT_L] = (SQRT3 / 2.0f * mbot_vel_cmd.vx - 0.5f * mbot_vel_cmd.vy - OMNI_BASE_RADIUS * mbot_vel_cmd.wz) / OMNI_WHEEL_RADIUS;
+            mbot_motor_vel_cmd.velocity[MOT_R] = (-SQRT3 / 2.0f * mbot_vel_cmd.vx - 0.5f * mbot_vel_cmd.vy - OMNI_BASE_RADIUS * mbot_vel_cmd.wz) / OMNI_WHEEL_RADIUS;
             mbot_motor_vel_cmd.velocity[MOT_B] = (mbot_vel_cmd.vy - OMNI_BASE_RADIUS * mbot_vel_cmd.wz) / OMNI_WHEEL_RADIUS;
-            float vel_left_comp = params.motor_polarity[MOT_L] * mbot_motor_vel_cmd.velocity[MOT_L];
-            float vel_right_comp = params.motor_polarity[MOT_R] * mbot_motor_vel_cmd.velocity[MOT_R];
-            float vel_back_comp = params.motor_polarity[MOT_B] * mbot_motor_vel_cmd.velocity[MOT_B];
+            float vel_left_comp = (float)params.motor_polarity[MOT_L] * mbot_motor_vel_cmd.velocity[MOT_L];
+            float vel_right_comp = (float)params.motor_polarity[MOT_R] * mbot_motor_vel_cmd.velocity[MOT_R];
+            float vel_back_comp = (float)params.motor_polarity[MOT_B] * mbot_motor_vel_cmd.velocity[MOT_B];
 
             mbot_motor_pwm.utime = global_utime;
             mbot_motor_pwm_cmd.pwm[MOT_R] = _calibrated_pwm_from_vel_cmd(vel_right_comp, MOT_R);
@@ -139,7 +146,7 @@ int main()
 
     while(running){
         // Print State
-        mbot_print_state(mbot_imu, mbot_encoders, mbot_odometry, mbot_motor_vel);
+        // mbot_print_state(mbot_imu, mbot_encoders, mbot_odometry, mbot_motor_vel);
         sleep_ms(200);
     }
 }

--- a/src/mbot_omni.c
+++ b/src/mbot_omni.c
@@ -61,13 +61,6 @@ bool mbot_loop(repeating_timer_t *rt)
             mbot_motor_pwm_cmd.pwm[MOT_B] = _calibrated_pwm_from_vel_cmd(mbot_motor_vel_cmd.velocity[MOT_B], MOT_B);
         }else if(drive_mode == MODE_MBOT_VEL){
             //TODO: open loop for now - implement closed loop controller
-
-            printf("vx: %f, vy: %f, wz: %f\n", mbot_vel_cmd.vx, mbot_vel_cmd.vy, mbot_vel_cmd.wz);
-            printf("sqrt3: %f, base_radius: %f, wheel_radius: %f\n", SQRT3, OMNI_BASE_RADIUS, OMNI_WHEEL_RADIUS);
-            printf("%f\n", ( ((SQRT3 / 2.0f) * mbot_vel_cmd.vx) - (mbot_vel_cmd.vy / 2.0f) - (OMNI_BASE_RADIUS * mbot_vel_cmd.wz) ) / OMNI_WHEEL_RADIUS);
-            printf("%f\n", (-SQRT3 / 2.0f * mbot_vel_cmd.vx - 0.5f * mbot_vel_cmd.vy - OMNI_BASE_RADIUS * mbot_vel_cmd.wz) / OMNI_WHEEL_RADIUS);
-            printf("%f\n", (mbot_vel_cmd.vy - OMNI_BASE_RADIUS * mbot_vel_cmd.wz) / OMNI_WHEEL_RADIUS);
-
             mbot_motor_vel_cmd.velocity[MOT_L] = (SQRT3 / 2.0f * mbot_vel_cmd.vx - 0.5f * mbot_vel_cmd.vy - OMNI_BASE_RADIUS * mbot_vel_cmd.wz) / OMNI_WHEEL_RADIUS;
             mbot_motor_vel_cmd.velocity[MOT_R] = (-SQRT3 / 2.0f * mbot_vel_cmd.vx - 0.5f * mbot_vel_cmd.vy - OMNI_BASE_RADIUS * mbot_vel_cmd.wz) / OMNI_WHEEL_RADIUS;
             mbot_motor_vel_cmd.velocity[MOT_B] = (mbot_vel_cmd.vy - OMNI_BASE_RADIUS * mbot_vel_cmd.wz) / OMNI_WHEEL_RADIUS;
@@ -146,7 +139,7 @@ int main()
 
     while(running){
         // Print State
-        // mbot_print_state(mbot_imu, mbot_encoders, mbot_odometry, mbot_motor_vel);
+        mbot_print_state(mbot_imu, mbot_encoders, mbot_odometry, mbot_motor_vel);
         sleep_ms(200);
     }
 }

--- a/src/mbot_omni.h
+++ b/src/mbot_omni.h
@@ -26,9 +26,9 @@
 // Some useful math definitions.
 #define OMNI_MOTOR_ANGLE_LFT (-M_PI / 6.0f)   // Left wheel velocity angle (-30 degrees)
 #define OMNI_MOTOR_ANGLE_BCK (M_PI / 2.0f)           // Back wheel velocity angle (90 degrees)
-#define OMNI_MOTOR_ANGLE_RGT (-5.0 * M_PI / 6.0f)    // Right wheel velocity angle (-150 degrees)
-#define SQRT3                   1.732050807568877
-#define INV_SQRT3               5.7735026918962575E-1
+#define OMNI_MOTOR_ANGLE_RGT (-5.0f * M_PI / 6.0f)    // Right wheel velocity angle (-150 degrees)
+#define SQRT3                   1.732050807568877f
+#define INV_SQRT3               5.7735026918962575E-1f
 
 /**
  * @brief Calculate the body velocity of an omnidirectional (Kiwi) robot


### PR DESCRIPTION
Fixes issue with conversion between MBot velocity commands and motor commands.

The issue was in `mbot_omni_config.h`. This was the definition of `OMNI_WHEEL_RADIUS`:
```c
/* The user can set the wheel diameter to 101 or 96 mm with a CMake arg. */
#ifdef USER_OMNI_WHEEL_DIAMETER
#define OMNI_WHEEL_RADIUS       USER_OMNI_WHEEL_DIAMETER / 2000.0  // Convert to radius in meters.
#else
#define OMNI_WHEEL_RADIUS       0.048       // Default wheel radius.
#endif   /* USER_ENCODER_RES */
```

Which is used in `mbot_omni.c` on lines 64-66:
```c
mbot_motor_vel_cmd.velocity[MOT_L] = (SQRT3 / 2.0f * mbot_vel_cmd.vx - 0.5f * mbot_vel_cmd.vy - OMNI_BASE_RADIUS * mbot_vel_cmd.wz) / OMNI_WHEEL_RADIUS;
```

Which in the case of the user defined parameter from `CMakeLists.txt`, equivalently expands to:
```c
mbot_motor_vel_cmd.velocity[MOT_L] = (SQRT3 / 2.0f * mbot_vel_cmd.vx - 0.5f * mbot_vel_cmd.vy - OMNI_BASE_RADIUS * mbot_vel_cmd.wz) /  USER_OMNI_WHEEL_DIAMETER / 2000.0;
```

**instead of**

```c
mbot_motor_vel_cmd.velocity[MOT_L] = (SQRT3 / 2.0f * mbot_vel_cmd.vx - 0.5f * mbot_vel_cmd.vy - OMNI_BASE_RADIUS * mbot_vel_cmd.wz) /  (USER_OMNI_WHEEL_DIAMETER / 2000.0);
```

So the new definition of `OMNI_WHEEL_RADIUS` is:
```c
/* The user can set the wheel diameter to 101 or 96 mm with a CMake arg. */
#ifdef USER_OMNI_WHEEL_DIAMETER
#define OMNI_WHEEL_RADIUS       ((float)USER_OMNI_WHEEL_DIAMETER / 2000.0f)  // Convert to radius in meters.
#else
#define OMNI_WHEEL_RADIUS       0.048f       // Default wheel radius.
#endif   /* USER_ENCODER_RES */
```

**_PEMDAS!_**
