### PR TITLE
Bugfix/mbot controller

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ endfunction()
 
 if(MBOT_TYPE STREQUAL "CLASSIC")
   # MBOT Classic Main.
+  add_definitions(-DMBOT_TYPE_CLASSIC)
   set(MBOT_CLASSIC mbot_classic${NAME_SUFFIX})
   add_executable(${MBOT_CLASSIC}
     src/mbot_controller.c
@@ -138,6 +139,7 @@ if(MBOT_TYPE STREQUAL "CLASSIC")
 
 elseif(MBOT_TYPE STREQUAL "OMNI")
   # MBOT Omni
+  add_definitions(-DMBOT_TYPE_OMNI)
   set(MBOT_OMNI mbot_omni${NAME_SUFFIX})
   add_executable(${MBOT_OMNI}
     src/mbot_controller.c

--- a/src/mbot_classic.h
+++ b/src/mbot_classic.h
@@ -20,6 +20,7 @@
 #include "mbot_print.h"
 #include "mbot_comms.h"
 #include "mbot_odometry.h"
+#include "mbot_controller.h"
 
 #include "config/mbot_classic_config.h"
 

--- a/src/mbot_controller.c
+++ b/src/mbot_controller.c
@@ -1,10 +1,11 @@
 #include "mbot_controller.h"
 
-#ifdef MBOT_TYPE_CLASSIC
-#include "config/mbot_classic_config.h"
-#elif defined(MBOT_TYPE_OMNI)
-#include "config/mbot_omni_config.h"
-#endif
+rc_filter_t left_wheel_pid;
+rc_filter_t right_wheel_pid;
+rc_filter_t back_wheel_pid;
+rc_filter_t mbot_vx_pid;
+rc_filter_t mbot_vy_pid;
+rc_filter_t mbot_wz_pid;
 
 int mbot_init_ctlr(mbot_ctlr_cfg_t ctlr_cfg) {
     left_wheel_pid = rc_filter_empty();

--- a/src/mbot_controller.c
+++ b/src/mbot_controller.c
@@ -1,27 +1,47 @@
 #include "mbot_controller.h"
 
-int mbot_init_ctlr(mbot_ctlr_cfg_t ctlr_cfg){
+#ifdef MBOT_TYPE_CLASSIC
+#include "config/mbot_classic_config.h"
+#elif defined(MBOT_TYPE_OMNI)
+#include "config/mbot_omni_config.h"
+#endif
+
+int mbot_init_ctlr(mbot_ctlr_cfg_t ctlr_cfg) {
     left_wheel_pid = rc_filter_empty();
     right_wheel_pid = rc_filter_empty();
     back_wheel_pid = rc_filter_empty();
     mbot_vx_pid = rc_filter_empty();
     mbot_vy_pid = rc_filter_empty();
     mbot_wz_pid = rc_filter_empty();
+
     rc_filter_pid(&left_wheel_pid, ctlr_cfg.left.kp, ctlr_cfg.left.ki, ctlr_cfg.left.kd, ctlr_cfg.left.Tf, MAIN_LOOP_PERIOD);
-    rc_filter_pid(&left_wheel_pid, ctlr_cfg.right.kp, ctlr_cfg.right.ki, ctlr_cfg.right.kd, ctlr_cfg.right.Tf, MAIN_LOOP_PERIOD);
-    rc_filter_pid(&left_wheel_pid, ctlr_cfg.back.kp, ctlr_cfg.back.ki, ctlr_cfg.back.kd, ctlr_cfg.back.Tf, MAIN_LOOP_PERIOD);
-    rc_filter_pid(&left_wheel_pid, ctlr_cfg.vx.kp, ctlr_cfg.vx.ki, ctlr_cfg.vx.kd, ctlr_cfg.vx.Tf, MAIN_LOOP_PERIOD);
-    rc_filter_pid(&left_wheel_pid, ctlr_cfg.vy.kp, ctlr_cfg.vy.ki, ctlr_cfg.vy.kd, ctlr_cfg.vy.Tf, MAIN_LOOP_PERIOD);
-    rc_filter_pid(&left_wheel_pid, ctlr_cfg.wz.kp, ctlr_cfg.wz.ki, ctlr_cfg.wz.kd, ctlr_cfg.wz.Tf, MAIN_LOOP_PERIOD);
+    rc_filter_pid(&right_wheel_pid, ctlr_cfg.right.kp, ctlr_cfg.right.ki, ctlr_cfg.right.kd, ctlr_cfg.right.Tf, MAIN_LOOP_PERIOD);
+    rc_filter_pid(&back_wheel_pid, ctlr_cfg.back.kp, ctlr_cfg.back.ki, ctlr_cfg.back.kd, ctlr_cfg.back.Tf, MAIN_LOOP_PERIOD);
+    rc_filter_pid(&mbot_vx_pid, ctlr_cfg.vx.kp, ctlr_cfg.vx.ki, ctlr_cfg.vx.kd, ctlr_cfg.vx.Tf, MAIN_LOOP_PERIOD);
+    rc_filter_pid(&mbot_vy_pid, ctlr_cfg.vy.kp, ctlr_cfg.vy.ki, ctlr_cfg.vy.kd, ctlr_cfg.vy.Tf, MAIN_LOOP_PERIOD);
+    rc_filter_pid(&mbot_wz_pid, ctlr_cfg.wz.kp, ctlr_cfg.wz.ki, ctlr_cfg.wz.kd, ctlr_cfg.wz.Tf, MAIN_LOOP_PERIOD);
+
+    return 0;
 }
 
-int mbot_motor_vel_ctlr(serial_mbot_motor_vel_t vel_cmd, serial_mbot_motor_vel_t vel, serial_mbot_motor_pwm_t *mbot_motor_pwm){
-    rc_filter_t filter = rc_filter_empty(); // Assume this is properly initialized
-    float right_error = vel_cmd.velocity[0] - vel.velocity[0];
-    float left_error = vel_cmd.velocity[1] - vel.velocity[1];
-    float back_error = vel_cmd.velocity[2] - vel.velocity[2];
-    float right_cmd = rc_filter_march(&filter, right_error);
-    float left_cmd = rc_filter_march(&filter, left_error);
-    float back_cmd = rc_filter_march(&filter, back_error);
+int mbot_motor_vel_ctlr(serial_mbot_motor_vel_t vel_cmd, serial_mbot_motor_vel_t vel, serial_mbot_motor_pwm_t *mbot_motor_pwm) {
+    float right_error = vel_cmd.velocity[MOT_R] - vel.velocity[MOT_R];
+    float left_error = vel_cmd.velocity[MOT_L] - vel.velocity[MOT_L];
+    float right_cmd = rc_filter_march(&right_wheel_pid, right_error);
+    float left_cmd = rc_filter_march(&left_wheel_pid, left_error);
+
+    mbot_motor_pwm->pwm[MOT_R] = right_cmd;
+    mbot_motor_pwm->pwm[MOT_L] = left_cmd;
+
+    #ifdef MBOT_TYPE_OMNI
+    float back_error = vel_cmd.velocity[MOT_B] - vel.velocity[MOT_B];
+    float back_cmd = rc_filter_march(&back_wheel_pid, back_error);
+    mbot_motor_pwm->pwm[MOT_B] = back_cmd;
+    #endif
+
+    return 0;
+}
+
+int mbot_ctlr(serial_twist2D_t vel_cmd, serial_twist2D_t vel, serial_mbot_motor_vel_t *mbot_motor_vel) {
     return 0;
 }

--- a/src/mbot_controller.h
+++ b/src/mbot_controller.h
@@ -1,6 +1,15 @@
+#ifndef MBOT_CONTROLLER_H
+#define MBOT_CONTROLLER_H
+
 #include <mbot_lcm_msgs_serial.h>
 #include <mbot/defs/mbot_params.h>
 #include <rc/math/filter.h>
+
+#ifdef MBOT_TYPE_CLASSIC
+#include "config/mbot_classic_config.h"
+#elif defined(MBOT_TYPE_OMNI)
+#include "config/mbot_omni_config.h"
+#endif
 
 typedef struct mbot_pid_cfg_t{
     float kp;
@@ -18,13 +27,8 @@ typedef struct mbot_ctlr_cfg_t{
     mbot_pid_cfg_t wz;
 } mbot_ctlr_cfg_t;
 
-rc_filter_t left_wheel_pid;
-rc_filter_t right_wheel_pid;
-rc_filter_t back_wheel_pid;
-rc_filter_t mbot_vx_pid;
-rc_filter_t mbot_vy_pid;
-rc_filter_t mbot_wz_pid;
-
 int mbot_init_ctlr(mbot_ctlr_cfg_t ctlr_cfg);
 int mbot_motor_vel_ctlr(serial_mbot_motor_vel_t vel_cmd, serial_mbot_motor_vel_t vel, serial_mbot_motor_pwm_t *mbot_motor_pwm);
 int mbot_ctlr(serial_twist2D_t vel_cmd, serial_twist2D_t vel, serial_mbot_motor_vel_t *mbot_motor_vel);
+
+#endif // MBOT_CONTROLLER_H


### PR DESCRIPTION
This PR addresses bugs in `mbot_controller.c` that prevented students from using the file directly in past semesters. 

1. Added definition in CMakeLists.txt so that `mbot_controller.c` can tell if it is classic or omni
2. Updated `mbot_controller.c` and `mbot_controller.h` according to lecture recording. Also changed the hardcode motor index to MOT_L, MBOT_R.