### PR TITLE
fixed typo, got rid of git error

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,8 +4,6 @@ sudo chmod -R 775 .git
 echo "[Setup] Updating submodules..."
 cd lib && git submodule update --init
 cd pico-sdk && git submodule update --init
-# git checkout master
-git pull
 cd ../../
 
 # set PICO_SDK_PATH

--- a/src/mbot_comms.c
+++ b/src/mbot_comms.c
@@ -18,8 +18,8 @@ void register_topics()
     comms_register_topic(MBOT_TIMESYNC, sizeof(serial_timestamp_t), (Deserialize)&timestamp_t_deserialize, (Serialize)&timestamp_t_serialize, (MsgCb)&timestamp_cb);
     comms_register_topic(MBOT_ODOMETRY_RESET,  sizeof(serial_pose2D_t), (Deserialize)&pose2D_t_deserialize, (Serialize)&pose2D_t_serialize, (MsgCb)&reset_odometry_cb);
     comms_register_topic(MBOT_ENCODERS_RESET, sizeof(serial_mbot_encoders_t), (Deserialize)&mbot_encoders_t_deserialize, (Serialize)&mbot_encoders_t_serialize, (MsgCb)&reset_encoders_cb);
-    comms_register_topic(MBOT_MOTOR_PWM_CMD, sizeof(serial_mbot_motor_pwm_t), (Deserialize)&mbot_motor_pwm_t_deserialize, (Serialize)&mbot_motor_pwm_t_serialize, (MsgCb)mbot_motor_vel_cmd_cb);
-    comms_register_topic(MBOT_MOTOR_VEL_CMD, sizeof(serial_mbot_motor_vel_t), (Deserialize)&mbot_motor_vel_t_deserialize, (Serialize)&mbot_motor_vel_t_serialize, (MsgCb)mbot_motor_pwm_cmd_cb);
+    comms_register_topic(MBOT_MOTOR_PWM_CMD, sizeof(serial_mbot_motor_pwm_t), (Deserialize)&mbot_motor_pwm_t_deserialize, (Serialize)&mbot_motor_pwm_t_serialize, (MsgCb)mbot_motor_pwm_cmd_cb);
+    comms_register_topic(MBOT_MOTOR_VEL_CMD, sizeof(serial_mbot_motor_vel_t), (Deserialize)&mbot_motor_vel_t_deserialize, (Serialize)&mbot_motor_vel_t_serialize, (MsgCb)mbot_motor_vel_cmd_cb);
     comms_register_topic(MBOT_VEL_CMD, sizeof(serial_twist2D_t), (Deserialize)&twist2D_t_deserialize, (Serialize)&twist2D_t_serialize, (MsgCb)mbot_vel_cmd_cb);
 
     // Published Topics
@@ -49,7 +49,7 @@ int mbot_init_comms(void){
 }
 
 void timestamp_cb(serial_timestamp_t *msg)
-{   
+{
     // msg->utime: current time in microseconds since the Unix epoch
     global_pico_time = to_us_since_boot(get_absolute_time());
     timestamp_offset = msg->utime - global_pico_time;


### PR DESCRIPTION
What's new:
1. Removed `git pull` from setup.sh, submodules are fixed to a specific commit, it doesn't do anything but bring in git warnings, the warning is confusing to the users
2. Fixed typo in comms.c, the callback functions were mixed up